### PR TITLE
Selection operator fix in resistance scoring doc

### DIFF
--- a/docs/detection-ttv/scoringanalytic.rst
+++ b/docs/detection-ttv/scoringanalytic.rst
@@ -177,12 +177,14 @@ the ``selection_malleable_profile*`` conditions is met, unless the filter
 condition is also true. There are four sections in
 ``selection_malleable_profile``: ``PipeName | startswith``, ``PipeName``,
 ``selection_malleable_profile_CatalogChangeListener``, and ``PipeName |
-endswith``. The observables within each of the selections are connected using an
-AND. The condition states that at least one of the
-``selection_malleable_profile*`` will be selected, making each of the selections
-connected by an OR. So, the final analytic would look like this:
+endswith``. The observables within ``selection_malleable_profiles``
+are connected using an OR, while observables within
+``selection_malleable_profile_CatalogChangeListener`` are connected using an AND.
+The condition states that at least one of the ``selection_malleable_profile*``
+will be selected, making each of the selections connected by an OR.
+So, the final analytic would look like this:
 
-``((selection_malleable_profiles: Pipename | startswith AND Pipename) OR
+``((selection_malleable_profiles: Pipename | startswith OR Pipename) OR
 (selection_malleable_profile_CatalogChangeListener: Pipename | startswith AND
 Pipename | endswith)) AND (NOT filter) = (1 AND 1) AND 3  = 1``
 


### PR DESCRIPTION
According to the Sigma specification, when the [list](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#lists) is used, fields are connected using OR operator, AND operator is used for the [map](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#maps).

In `selection_malleable_profiles` the list is used.

```yaml
   selection_malleable_profiles:
      - PipeName|startswith:
            - '\mojo.5688.8052.183894939787088877'
            - '\mojo.5688.8052.35780273329370473'
            - '\mypipe-f'
            - '\mypipe-h'
            - '\ntsvcs'
            - '\scerpc'
            - '\win_svc'
            - '\spoolss'
            - '\msrpc_'
            - '\win\msrpc_'
            - '\wkssvc'
            - '\f53f'
            - '\windows.update.manager'
            - '\SearchTextHarvester'
            - '\DserNamePipe'
            - '\PGMessagePipe'
            - '\MsFteWds'
            - '\f4c3'
            - '\fullduplex_'
            - '\rpc_'
      - PipeName:
            - '\demoagent_11'
            - '\demoagent_22'
```



Thus, the boolean for this selection should be corrected:

```diff
- (selection_malleable_profiles: Pipename | startswith AND Pipename)
+ (selection_malleable_profiles: Pipename | startswith OR Pipename)
```

As well as the explanation above it:
```diff
- The observables within each of the selections are connected using an AND.
+ The observables within ``selection_malleable_profiles`` are connected using an OR, while observables within ``selection_malleable_profile_CatalogChangeListener`` are connected using an AND.
```